### PR TITLE
Add terminal-style portfolio design

### DIFF
--- a/experience.html
+++ b/experience.html
@@ -22,60 +22,64 @@
             <!-- Back link -->
             <a href="index.html" class="back-link">$ cd ..</a>
 
-            <!-- ls -la command -->
-            <div class="command-line">
-                <span class="prompt">$</span>
-                <span class="command"> cat experience.log</span>
+            <!-- Section Title -->
+            <div class="section-header">
+                <span class="section-icon">&#128188;</span>
+                <h2 class="section-title">Professional experience</h2>
             </div>
 
             <div class="experience-section">
-                <!-- Experience Item 1 -->
-                <div class="experience-item">
-                    <span class="experience-year">2024 - Present</span>
-                    <h3 class="experience-title">Senior Software Engineer</h3>
-                    <p class="experience-company">Example Company Inc.</p>
-                    <p class="experience-desc">
-                        バックエンド開発、インフラ設計、チームリードなど。<br>
-                        技術スタック: Go, Kubernetes, AWS
-                    </p>
+                <!-- Experience Item 1: GOGEN -->
+                <div class="experience-item-new">
+                    <div class="experience-header">
+                        <h3 class="experience-role">執行役員 CTO</h3>
+                        <span class="experience-date">2022 - Present</span>
+                    </div>
+                    <p class="experience-company-new">GOGEN株式会社 / Full-time</p>
+
+                    <ul class="experience-list">
+                        <li>技術戦略の策定と実行、エンジニアリング組織のマネジメント</li>
+                        <li>プロダクト開発の技術的リード、アーキテクチャ設計</li>
+                        <li>採用活動、エンジニア育成、チームビルディング</li>
+                        <li>開発プロセス改善、DevOps/SRE推進</li>
+                    </ul>
+
+                    <div class="tech-stack">
+                        <span class="tech-label">Technology Stack</span>
+                        <div class="tech-tags">
+                            <span class="tech-tag">Go</span>
+                            <span class="tech-tag">TypeScript</span>
+                            <span class="tech-tag">Kubernetes</span>
+                            <span class="tech-tag">AWS</span>
+                            <span class="tech-tag">Terraform</span>
+                            <span class="tech-tag">Docker</span>
+                        </div>
+                    </div>
                 </div>
 
-                <!-- Experience Item 2 -->
-                <div class="experience-item">
-                    <span class="experience-year">2021 - 2024</span>
-                    <h3 class="experience-title">Software Engineer</h3>
-                    <p class="experience-company">Previous Company Ltd.</p>
-                    <p class="experience-desc">
-                        Webアプリケーション開発、API設計。<br>
-                        技術スタック: Python, Docker, GCP
-                    </p>
-                </div>
+                <!-- Placeholder for additional experience -->
+                <div class="experience-item-new">
+                    <div class="experience-header">
+                        <h3 class="experience-role">Software Engineer</h3>
+                        <span class="experience-date">20XX - 2022</span>
+                    </div>
+                    <p class="experience-company-new">Previous Company / Full-time</p>
 
-                <!-- Experience Item 3 -->
-                <div class="experience-item">
-                    <span class="experience-year">2018 - 2021</span>
-                    <h3 class="experience-title">Junior Engineer</h3>
-                    <p class="experience-company">First Company Corp.</p>
-                    <p class="experience-desc">
-                        新卒入社。フロントエンド・バックエンドの基礎を習得。<br>
-                        技術スタック: JavaScript, Node.js, MySQL
-                    </p>
-                </div>
-            </div>
+                    <ul class="experience-list">
+                        <li>バックエンド開発、API設計・実装</li>
+                        <li>インフラ構築、CI/CD環境整備</li>
+                        <li>パフォーマンス改善、システム運用</li>
+                    </ul>
 
-            <!-- Skills section -->
-            <div class="command-line" style="margin-top: 30px;">
-                <span class="prompt">$</span>
-                <span class="command"> cat skills.txt</span>
-            </div>
-            <div class="command-output" data-command-delay="300">
-                <div class="links-list" style="margin-top: 12px;">
-                    <span class="link-item" style="cursor: default;">Go</span>
-                    <span class="link-item" style="cursor: default;">Python</span>
-                    <span class="link-item" style="cursor: default;">Kubernetes</span>
-                    <span class="link-item" style="cursor: default;">Docker</span>
-                    <span class="link-item" style="cursor: default;">AWS</span>
-                    <span class="link-item" style="cursor: default;">GCP</span>
+                    <div class="tech-stack">
+                        <span class="tech-label">Technology Stack</span>
+                        <div class="tech-tags">
+                            <span class="tech-tag">Go</span>
+                            <span class="tech-tag">Python</span>
+                            <span class="tech-tag">Docker</span>
+                            <span class="tech-tag">GCP</span>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/experience.html
+++ b/experience.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="zabio3 - 経歴・職歴">
+    <link rel="icon" href="favicon.ico">
+    <link rel="stylesheet" href="style.css">
+    <title>Experience | zabio3</title>
+</head>
+<body>
+    <div class="terminal">
+        <div class="terminal-header">
+            <div class="terminal-buttons">
+                <span class="terminal-button red"></span>
+                <span class="terminal-button yellow"></span>
+                <span class="terminal-button green"></span>
+            </div>
+            <span class="terminal-title">zabio3@portfolio ~/experience</span>
+        </div>
+        <div class="terminal-body">
+            <!-- Back link -->
+            <a href="index.html" class="back-link">$ cd ..</a>
+
+            <!-- ls -la command -->
+            <div class="command-line">
+                <span class="prompt">$</span>
+                <span class="command"> cat experience.log</span>
+            </div>
+
+            <div class="experience-section">
+                <!-- Experience Item 1 -->
+                <div class="experience-item">
+                    <span class="experience-year">2024 - Present</span>
+                    <h3 class="experience-title">Senior Software Engineer</h3>
+                    <p class="experience-company">Example Company Inc.</p>
+                    <p class="experience-desc">
+                        バックエンド開発、インフラ設計、チームリードなど。<br>
+                        技術スタック: Go, Kubernetes, AWS
+                    </p>
+                </div>
+
+                <!-- Experience Item 2 -->
+                <div class="experience-item">
+                    <span class="experience-year">2021 - 2024</span>
+                    <h3 class="experience-title">Software Engineer</h3>
+                    <p class="experience-company">Previous Company Ltd.</p>
+                    <p class="experience-desc">
+                        Webアプリケーション開発、API設計。<br>
+                        技術スタック: Python, Docker, GCP
+                    </p>
+                </div>
+
+                <!-- Experience Item 3 -->
+                <div class="experience-item">
+                    <span class="experience-year">2018 - 2021</span>
+                    <h3 class="experience-title">Junior Engineer</h3>
+                    <p class="experience-company">First Company Corp.</p>
+                    <p class="experience-desc">
+                        新卒入社。フロントエンド・バックエンドの基礎を習得。<br>
+                        技術スタック: JavaScript, Node.js, MySQL
+                    </p>
+                </div>
+            </div>
+
+            <!-- Skills section -->
+            <div class="command-line" style="margin-top: 30px;">
+                <span class="prompt">$</span>
+                <span class="command"> cat skills.txt</span>
+            </div>
+            <div class="command-output" data-command-delay="300">
+                <div class="links-list" style="margin-top: 12px;">
+                    <span class="link-item" style="cursor: default;">Go</span>
+                    <span class="link-item" style="cursor: default;">Python</span>
+                    <span class="link-item" style="cursor: default;">Kubernetes</span>
+                    <span class="link-item" style="cursor: default;">Docker</span>
+                    <span class="link-item" style="cursor: default;">AWS</span>
+                    <span class="link-item" style="cursor: default;">GCP</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/experience.html
+++ b/experience.html
@@ -155,20 +155,6 @@
                         </div>
                     </div>
                 </div>
-
-                <!-- Education -->
-                <div class="section-header" style="margin-top: 32px;">
-                    <span class="section-icon">&#127891;</span>
-                    <h2 class="section-title">Education</h2>
-                </div>
-
-                <div class="experience-item-new">
-                    <div class="experience-header">
-                        <h3 class="experience-role">理工学部 電気電子工学科</h3>
-                        <span class="experience-date">2010/04 - 2014/03</span>
-                    </div>
-                    <p class="experience-company-new">法政大学</p>
-                </div>
             </div>
         </div>
     </div>

--- a/experience.html
+++ b/experience.html
@@ -9,7 +9,7 @@
     <title>Experience | zabio3</title>
 </head>
 <body>
-    <div class="terminal">
+    <div class="terminal terminal-wide">
         <div class="terminal-header">
             <div class="terminal-buttons">
                 <span class="terminal-button red"></span>
@@ -29,19 +29,19 @@
             </div>
 
             <div class="experience-section">
-                <!-- Experience Item 1: GOGEN -->
+                <!-- GOGEN -->
                 <div class="experience-item-new">
                     <div class="experience-header">
                         <h3 class="experience-role">執行役員 CTO</h3>
-                        <span class="experience-date">2022 - Present</span>
+                        <span class="experience-date">2022/02 - Present</span>
                     </div>
-                    <p class="experience-company-new">GOGEN株式会社 / Full-time</p>
+                    <p class="experience-company-new">GOGEN株式会社 / 正社員</p>
 
                     <ul class="experience-list">
-                        <li>技術戦略の策定と実行、エンジニアリング組織のマネジメント</li>
-                        <li>プロダクト開発の技術的リード、アーキテクチャ設計</li>
-                        <li>採用活動、エンジニア育成、チームビルディング</li>
-                        <li>開発プロセス改善、DevOps/SRE推進</li>
+                        <li>不動産売買に関わるSaaSプロダクト群の開発を統括</li>
+                        <li>エンジニアとデザイナーで構成されるプロダクト部の部長</li>
+                        <li>チーム運営やプロダクトの意思決定を担当</li>
+                        <li>プロダクトを軸に、現場と経営のあいだをつなぎ直し、チーム全体の出力を最大化</li>
                     </ul>
 
                     <div class="tech-stack">
@@ -52,23 +52,74 @@
                             <span class="tech-tag">Kubernetes</span>
                             <span class="tech-tag">AWS</span>
                             <span class="tech-tag">Terraform</span>
-                            <span class="tech-tag">Docker</span>
                         </div>
                     </div>
                 </div>
 
-                <!-- Placeholder for additional experience -->
+                <!-- Alcanforero (Freelance) -->
                 <div class="experience-item-new">
                     <div class="experience-header">
-                        <h3 class="experience-role">Software Engineer</h3>
-                        <span class="experience-date">20XX - 2022</span>
+                        <h3 class="experience-role">Software Engineer / PM / SRE</h3>
+                        <span class="experience-date">2022/01 - 2023/05</span>
                     </div>
-                    <p class="experience-company-new">Previous Company / Full-time</p>
+                    <p class="experience-company-new">Alcanforero合同会社（フリーランス）</p>
 
                     <ul class="experience-list">
-                        <li>バックエンド開発、API設計・実装</li>
-                        <li>インフラ構築、CI/CD環境整備</li>
-                        <li>パフォーマンス改善、システム運用</li>
+                        <li>toC向けスタートアップ: Goの促進（メンター）、検索エンジンのリプレイス</li>
+                        <li>toC向け外資系スタートアップ: 新規サービスのインフラマネジメント（SRE）</li>
+                        <li>買収した保険外サービス（3つ）のサービス移管、コスト削減、セキュリティ対応</li>
+                        <li>toC向けスタートアップ（シリーズB）: 新規サービスの機能開発、基盤改善</li>
+                    </ul>
+
+                    <div class="tech-stack">
+                        <span class="tech-label">Technology Stack</span>
+                        <div class="tech-tags">
+                            <span class="tech-tag">Go</span>
+                            <span class="tech-tag">Kubernetes</span>
+                            <span class="tech-tag">GCP</span>
+                            <span class="tech-tag">AWS</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- DeNA -->
+                <div class="experience-item-new">
+                    <div class="experience-header">
+                        <h3 class="experience-role">Infrastructure Engineer</h3>
+                        <span class="experience-date">2018/12 - 2022/04</span>
+                    </div>
+                    <p class="experience-company-new">株式会社ディー・エヌ・エー / 正社員</p>
+
+                    <ul class="experience-list">
+                        <li>ゲーム・エンタメ領域のサービス運用・開発</li>
+                        <li>全社横断のインフラ技術ツールなどの開発</li>
+                        <li>PC向けゲームプラットフォームの開発・運用</li>
+                        <li>決済基盤責任者</li>
+                    </ul>
+
+                    <div class="tech-stack">
+                        <span class="tech-label">Technology Stack</span>
+                        <div class="tech-tags">
+                            <span class="tech-tag">Go</span>
+                            <span class="tech-tag">Kubernetes</span>
+                            <span class="tech-tag">GCP</span>
+                            <span class="tech-tag">AWS</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Side Projects -->
+                <div class="experience-item-new">
+                    <div class="experience-header">
+                        <h3 class="experience-role">Software Engineer (副業)</h3>
+                        <span class="experience-date">2019/10 - 2021/09</span>
+                    </div>
+                    <p class="experience-company-new">複数スタートアップ / 業務委託</p>
+
+                    <ul class="experience-list">
+                        <li>EdTech: 教材のレコメンド機能開発、離脱防止のリマインド機能</li>
+                        <li>AI文字起こしサービス: 新規プロダクトの0→1開発、バックエンド・インフラ構築</li>
+                        <li>風力発電: 風車の故障検出機構築、Kubernetesへの移行、推論実行の排他制御</li>
                     </ul>
 
                     <div class="tech-stack">
@@ -76,10 +127,47 @@
                         <div class="tech-tags">
                             <span class="tech-tag">Go</span>
                             <span class="tech-tag">Python</span>
-                            <span class="tech-tag">Docker</span>
+                            <span class="tech-tag">Kubernetes</span>
                             <span class="tech-tag">GCP</span>
                         </div>
                     </div>
+                </div>
+
+                <!-- Accelia -->
+                <div class="experience-item-new">
+                    <div class="experience-header">
+                        <h3 class="experience-role">Software Engineer</h3>
+                        <span class="experience-date">2014/04 - 2018/12</span>
+                    </div>
+                    <p class="experience-company-new">Accelia, Inc. / 正社員</p>
+
+                    <ul class="experience-list">
+                        <li>CDNの開発・運用</li>
+                        <li>DDoS防御サービスの開発・運用</li>
+                    </ul>
+
+                    <div class="tech-stack">
+                        <span class="tech-label">Technology Stack</span>
+                        <div class="tech-tags">
+                            <span class="tech-tag">C</span>
+                            <span class="tech-tag">Linux</span>
+                            <span class="tech-tag">Network</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Education -->
+                <div class="section-header" style="margin-top: 32px;">
+                    <span class="section-icon">&#127891;</span>
+                    <h2 class="section-title">Education</h2>
+                </div>
+
+                <div class="experience-item-new">
+                    <div class="experience-header">
+                        <h3 class="experience-role">理工学部 電気電子工学科</h3>
+                        <span class="experience-date">2010/04 - 2014/03</span>
+                    </div>
+                    <p class="experience-company-new">法政大学</p>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -3,10 +3,67 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="zabio3 - Software Engineer Portfolio">
     <link rel="icon" href="favicon.ico">
-    <title>zabio3</title>
+    <link rel="stylesheet" href="style.css">
+    <title>zabio3 | Software Engineer</title>
 </head>
 <body>
-    zabio3
+    <div class="terminal">
+        <div class="terminal-header">
+            <div class="terminal-buttons">
+                <span class="terminal-button red"></span>
+                <span class="terminal-button yellow"></span>
+                <span class="terminal-button green"></span>
+            </div>
+            <span class="terminal-title">zabio3@portfolio ~ bash</span>
+        </div>
+        <div class="terminal-body">
+            <!-- ASCII Art Logo -->
+            <pre class="ascii-art">
+███████╗ █████╗ ██████╗ ██╗ ██████╗ ██████╗
+╚══███╔╝██╔══██╗██╔══██╗██║██╔═══██╗╚════██╗
+  ███╔╝ ███████║██████╔╝██║██║   ██║ █████╔╝
+ ███╔╝  ██╔══██║██╔══██╗██║██║   ██║ ╚═══██╗
+███████╗██║  ██║██████╔╝██║╚██████╔╝██████╔╝
+╚══════╝╚═╝  ╚═╝╚═════╝ ╚═╝ ╚═════╝ ╚═════╝
+            </pre>
+
+            <!-- whoami command -->
+            <div class="command-line">
+                <span class="prompt">$</span>
+                <span class="command"> whoami</span>
+            </div>
+            <div class="command-output" data-command-delay="300">
+                <span class="output">> Software Engineer</span>
+            </div>
+
+            <!-- cat links.txt command -->
+            <div class="command-line" style="margin-top: 20px;">
+                <span class="prompt">$</span>
+                <span class="command"> cat links.txt</span>
+            </div>
+            <div class="command-output" data-command-delay="600">
+                <div class="links-list">
+                    <a href="https://github.com/zabio3" target="_blank" rel="noopener noreferrer" class="link-item">GitHub</a>
+                    <a href="https://jp.linkedin.com/in/tomohiro-kusumoto-b8b108152" target="_blank" rel="noopener noreferrer" class="link-item">LinkedIn</a>
+                    <a href="https://note.com/zabio3" target="_blank" rel="noopener noreferrer" class="link-item">note</a>
+                    <a href="https://sizu.me/zabio3" target="_blank" rel="noopener noreferrer" class="link-item">sizu.me</a>
+                    <a href="https://x.com/zabio_3" target="_blank" rel="noopener noreferrer" class="link-item">X</a>
+                </div>
+            </div>
+
+            <!-- cd experience command -->
+            <div class="command-line" style="margin-top: 20px;">
+                <span class="prompt">$</span>
+                <span class="command"> cd experience</span>
+            </div>
+            <div class="command-output" data-command-delay="900">
+                <a href="experience.html" class="nav-link">> 経歴を見る <span class="arrow">→</span></a>
+            </div>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,103 @@
+// Terminal Portfolio - zabio3
+// Typing Animation Script
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Get all elements with typing animation
+  const typingElements = document.querySelectorAll('[data-typing]');
+
+  typingElements.forEach((element, index) => {
+    const text = element.getAttribute('data-typing');
+    const delay = parseInt(element.getAttribute('data-delay')) || index * 1000;
+    const speed = parseInt(element.getAttribute('data-speed')) || 50;
+
+    element.textContent = '';
+    element.style.visibility = 'visible';
+
+    setTimeout(() => {
+      typeText(element, text, speed);
+    }, delay);
+  });
+
+  // Sequential typing for command outputs
+  const commandOutputs = document.querySelectorAll('.command-output');
+  let totalDelay = 0;
+
+  commandOutputs.forEach((output) => {
+    const commandDelay = parseInt(output.getAttribute('data-command-delay')) || 500;
+    totalDelay += commandDelay;
+
+    output.style.opacity = '0';
+
+    setTimeout(() => {
+      output.style.opacity = '1';
+      output.style.transition = 'opacity 0.3s ease';
+    }, totalDelay);
+  });
+});
+
+function typeText(element, text, speed) {
+  let i = 0;
+  const cursor = document.createElement('span');
+  cursor.className = 'cursor';
+  element.appendChild(cursor);
+
+  function type() {
+    if (i < text.length) {
+      element.insertBefore(document.createTextNode(text.charAt(i)), cursor);
+      i++;
+      setTimeout(type, speed);
+    }
+  }
+
+  type();
+}
+
+// Matrix rain effect (optional background)
+function initMatrixRain() {
+  const canvas = document.getElementById('matrix-canvas');
+  if (!canvas) return;
+
+  const ctx = canvas.getContext('2d');
+
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+
+  const chars = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789ABCDEF';
+  const charArray = chars.split('');
+
+  const fontSize = 14;
+  const columns = canvas.width / fontSize;
+
+  const drops = [];
+  for (let i = 0; i < columns; i++) {
+    drops[i] = 1;
+  }
+
+  function draw() {
+    ctx.fillStyle = 'rgba(13, 17, 23, 0.05)';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = '#00ff41';
+    ctx.font = fontSize + 'px Fira Code';
+
+    for (let i = 0; i < drops.length; i++) {
+      const text = charArray[Math.floor(Math.random() * charArray.length)];
+      ctx.fillText(text, i * fontSize, drops[i] * fontSize);
+
+      if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) {
+        drops[i] = 0;
+      }
+      drops[i]++;
+    }
+  }
+
+  setInterval(draw, 50);
+
+  window.addEventListener('resize', () => {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  });
+}
+
+// Initialize matrix rain if canvas exists
+initMatrixRain();

--- a/style.css
+++ b/style.css
@@ -299,3 +299,141 @@ body {
 .glow {
   text-shadow: 0 0 10px currentColor;
 }
+
+/* Section Header */
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-icon {
+  font-size: 1.5rem;
+}
+
+.section-title {
+  color: var(--text-white);
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+/* New Experience Item Style */
+.experience-item-new {
+  margin-bottom: 32px;
+  padding: 20px;
+  background-color: var(--bg-secondary);
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  transition: border-color 0.2s ease;
+}
+
+.experience-item-new:hover {
+  border-color: var(--text-cyan);
+}
+
+.experience-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.experience-role {
+  color: var(--text-cyan);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.experience-date {
+  color: var(--text-gray);
+  font-size: 0.85rem;
+  background-color: var(--bg-primary);
+  padding: 2px 10px;
+  border-radius: 12px;
+}
+
+.experience-company-new {
+  color: var(--text-gray);
+  font-size: 0.9rem;
+  margin-bottom: 16px;
+}
+
+/* Experience List */
+.experience-list {
+  list-style: none;
+  margin-bottom: 16px;
+}
+
+.experience-list li {
+  color: var(--text-green);
+  font-size: 0.9rem;
+  padding-left: 20px;
+  position: relative;
+  margin-bottom: 8px;
+  line-height: 1.5;
+}
+
+.experience-list li::before {
+  content: ">";
+  position: absolute;
+  left: 0;
+  color: var(--text-cyan);
+}
+
+/* Technology Stack */
+.tech-stack {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-color);
+}
+
+.tech-label {
+  color: var(--text-gray);
+  font-size: 0.8rem;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.tech-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tech-tag {
+  color: var(--text-green);
+  font-size: 0.8rem;
+  padding: 4px 10px;
+  border: 1px solid var(--text-green);
+  border-radius: 4px;
+  transition: all 0.2s ease;
+}
+
+.tech-tag:hover {
+  background-color: var(--text-green);
+  color: var(--bg-primary);
+}
+
+/* Responsive for new experience */
+@media (max-width: 480px) {
+  .experience-header {
+    flex-direction: column;
+  }
+
+  .experience-role {
+    font-size: 1rem;
+  }
+
+  .experience-list li {
+    font-size: 0.85rem;
+  }
+
+  .tech-tag {
+    font-size: 0.75rem;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,301 @@
+/* Terminal Portfolio - zabio3 */
+
+/* Google Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap');
+
+/* CSS Variables */
+:root {
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-terminal: #0a0e14;
+  --text-green: #00ff41;
+  --text-cyan: #00d9ff;
+  --text-gray: #8b949e;
+  --text-white: #e6edf3;
+  --link-hover: #58a6ff;
+  --border-color: #30363d;
+  --red: #ff5f56;
+  --yellow: #ffbd2e;
+  --green-dot: #27c93f;
+}
+
+/* Reset */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* Base */
+html {
+  font-size: 16px;
+}
+
+body {
+  font-family: 'Fira Code', monospace;
+  background-color: var(--bg-primary);
+  color: var(--text-green);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  line-height: 1.6;
+}
+
+/* Terminal Window */
+.terminal {
+  background-color: var(--bg-terminal);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  max-width: 700px;
+  width: 100%;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+/* Terminal Header */
+.terminal-header {
+  background-color: var(--bg-secondary);
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.terminal-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.terminal-button {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.terminal-button.red { background-color: var(--red); }
+.terminal-button.yellow { background-color: var(--yellow); }
+.terminal-button.green { background-color: var(--green-dot); }
+
+.terminal-title {
+  color: var(--text-gray);
+  font-size: 0.85rem;
+  flex-grow: 1;
+  text-align: center;
+  margin-right: 52px;
+}
+
+/* Terminal Body */
+.terminal-body {
+  padding: 24px;
+  min-height: 400px;
+}
+
+/* ASCII Art */
+.ascii-art {
+  color: var(--text-cyan);
+  font-size: 0.6rem;
+  line-height: 1.1;
+  margin-bottom: 24px;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+@media (min-width: 500px) {
+  .ascii-art {
+    font-size: 0.75rem;
+  }
+}
+
+/* Command Line */
+.command-line {
+  margin-bottom: 16px;
+}
+
+.prompt {
+  color: var(--text-cyan);
+}
+
+.command {
+  color: var(--text-white);
+}
+
+.output {
+  color: var(--text-green);
+  margin-left: 8px;
+  display: block;
+  margin-top: 4px;
+}
+
+/* Typing Animation */
+.typing-text {
+  display: inline;
+}
+
+.cursor {
+  display: inline-block;
+  width: 10px;
+  height: 1.2em;
+  background-color: var(--text-green);
+  margin-left: 2px;
+  animation: blink 1s step-end infinite;
+  vertical-align: text-bottom;
+}
+
+@keyframes blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+/* Links */
+.links-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+  margin-left: 8px;
+}
+
+.link-item {
+  color: var(--text-green);
+  text-decoration: none;
+  padding: 4px 12px;
+  border: 1px solid var(--text-green);
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  font-size: 0.9rem;
+}
+
+.link-item:hover {
+  background-color: var(--text-green);
+  color: var(--bg-primary);
+  box-shadow: 0 0 10px var(--text-green);
+}
+
+/* Navigation Link */
+.nav-link {
+  color: var(--text-cyan);
+  text-decoration: none;
+  display: inline-block;
+  margin-top: 8px;
+  margin-left: 8px;
+  transition: all 0.2s ease;
+}
+
+.nav-link:hover {
+  color: var(--link-hover);
+  text-shadow: 0 0 10px var(--link-hover);
+}
+
+.nav-link .arrow {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.nav-link:hover .arrow {
+  transform: translateX(5px);
+}
+
+/* Experience Page Styles */
+.experience-section {
+  margin-top: 20px;
+}
+
+.experience-item {
+  margin-bottom: 24px;
+  padding-left: 20px;
+  border-left: 2px solid var(--border-color);
+}
+
+.experience-item:hover {
+  border-left-color: var(--text-cyan);
+}
+
+.experience-year {
+  color: var(--text-cyan);
+  font-size: 0.85rem;
+}
+
+.experience-title {
+  color: var(--text-white);
+  margin: 4px 0;
+}
+
+.experience-company {
+  color: var(--text-gray);
+  font-size: 0.9rem;
+}
+
+.experience-desc {
+  color: var(--text-green);
+  font-size: 0.85rem;
+  margin-top: 8px;
+  opacity: 0.8;
+}
+
+/* Back Link */
+.back-link {
+  color: var(--text-gray);
+  text-decoration: none;
+  display: inline-block;
+  margin-bottom: 20px;
+  transition: color 0.2s ease;
+}
+
+.back-link:hover {
+  color: var(--text-cyan);
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  body {
+    padding: 10px;
+  }
+
+  .terminal-body {
+    padding: 16px;
+  }
+
+  .ascii-art {
+    font-size: 0.45rem;
+  }
+
+  .links-list {
+    gap: 8px;
+  }
+
+  .link-item {
+    font-size: 0.8rem;
+    padding: 4px 8px;
+  }
+}
+
+/* Scanline Effect (optional) */
+.terminal-body::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  opacity: 0.3;
+}
+
+.terminal-body {
+  position: relative;
+}
+
+/* Glow Effect */
+.glow {
+  text-shadow: 0 0 10px currentColor;
+}

--- a/style.css
+++ b/style.css
@@ -54,6 +54,10 @@ body {
   overflow: hidden;
 }
 
+.terminal.terminal-wide {
+  max-width: 900px;
+}
+
 /* Terminal Header */
 .terminal-header {
   background-color: var(--bg-secondary);


### PR DESCRIPTION
## Summary
- Redesign the portfolio site with a terminal/console-inspired dark theme
- Add ASCII art logo, command-prompt style UI elements
- Create experience page with career history
- Implement neon green color scheme with typing animations

## Test plan
- [ ] Open index.html in browser and verify terminal design
- [ ] Check all social links work correctly
- [ ] Navigate to experience.html and verify layout
- [ ] Test responsive design on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)